### PR TITLE
Refactor Requirements class into multiple Requirement classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   "scripts": {
     "test": "npm run eslint && npm run mocha",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
-    "start": "node $NODE_DEBUG_OPTION src/",
-    "start-windows": "node %NODE_DEBUG_OPTION% src/",
+    "start": "node src/",
+    "debug-linux": "node $NODE_DEBUG_OPTION src/",
+    "debug-windows": "node %NODE_DEBUG_OPTION% src/",
     "mocha": "mocha test/ --recursive --exit"
   },
   "dependencies": {


### PR DESCRIPTION
This is a proposal to replace the `Requirements` class by multiple `Requirement` classes. IMHO this results in a clearer separation of concerns.

This also changes the npm scripts once more, so that both normal execution (`start`) and debugging on Windows (`debug-winodws`) and Linux (`debug-linux`) are supported.

Additionally, I started to replace occurences of `console.error` by `throw Error()`. This provides stacktraces on errors.

As a nice side-effect, the not-implemented event requirements now return `false` resulting in these achievements not being granted.