### PR TITLE
Run linter on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+node_js:
+  - "8"
+  - "10"
+
+cache:
+  directories:
+    - "node_modules"
+
+before_install:
+  - npm i -g npm@6.1.0
+
+script:
+  # TODO: Change this to "npm test" once our tests are no longer failing.
+  #       "npm test" includes running eslint.
+  - npm run eslint


### PR DESCRIPTION
This configures TravisCI to automatically run the linter (and potentially tests, in the future). @frederike-ramin you need to setup TravisCI for this repository by going to https://github.com/marketplace/travis-ci and enabling TravisCI for this repository. Then login to https://travis-ci.com, visit your profile https://travis-ci.com/profile/frederike-ramin, and verify the repository is enabled.